### PR TITLE
Fix a race-condition that causes incorrect call deflect status

### DIFF
--- a/src/com/android/incallui/AnswerPresenter.java
+++ b/src/com/android/incallui/AnswerPresenter.java
@@ -23,6 +23,7 @@ import android.content.ServiceConnection;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.os.RemoteException;
+import android.provider.Settings;
 
 import com.android.dialer.util.TelecomUtil;
 import com.android.incallui.InCallPresenter.InCallState;
@@ -532,7 +533,7 @@ public class AnswerPresenter extends Presenter<AnswerPresenter.AnswerUi>
                 getUi().showTargets(QtiCallUtils.getIncomingCallAnswerOptions(
                         getUi().getContext(), withSms));
             }
-        } else if (isCallDeflectSupported(call.getExtras())) {
+        } else if (isCallDeflectSupported()) {
             /**
              * Only present the user with the option to deflect call,
              * if the incoming call is only an audio call.
@@ -554,12 +555,19 @@ public class AnswerPresenter extends Presenter<AnswerPresenter.AnswerUi>
     }
 
     /**
-     * Checks the call extra to conclude on the call deflect support.
+     * Checks the Settings to conclude on the call deflect support.
      * Returns true if call deflect is possible, false otherwise.
      */
-    public boolean isCallDeflectSupported(Bundle extras) {
-        return (extras != null) &&
-               extras.getBoolean(QtiImsInterfaceUtils.QTI_IMS_DEFLECT_EXTRA_KEY, false);
+    public boolean isCallDeflectSupported() {
+        int value = 0;
+        try{
+            value = android.provider.Settings.Global.getInt(
+                              getUi().getContext().getContentResolver(),
+                              QtiImsInterfaceUtils.QTI_IMS_DEFLECT_ENABLED);
+        } catch(Settings.SettingNotFoundException e) {
+            //do Nothing
+        }
+        return (value == 1);
     }
 
     interface AnswerUi extends Ui {


### PR DESCRIPTION
There is some period (from the moment that incoming call
notification received on ImsService side till the TelephonyConnection
is setup, that is, all listeners are registered) during which
updates/events applied to internal.telephony.Connection don't reach
(ignored) TelephonyConnection because simply listeners are still not
ready. E.g. If  extras are set the moment incoming call notification
reaches the ImsService the extras will be ignored since
TelephonyConnection object either not created or not yet listening
to the events from internal.telephony.Connection (Original Connection).
As a result when AnswerPresenter looks at the extra that indicates
if call deflect is supported, the extra is not set correctly. Hence,
user cannot see the option for call deflect for incoming call.

The use of extras for this information is questionable as the value
has to be propagated through multiple layers when the source of this
value is a configuration in xml. Moreover, due to the race condtion
above its not dependable in the incoming call scenario. The fix here
is to move the config item to shared settings.

Change-Id: Id3f1d6e11bee86894f15663a80314a0bbfd6d7d4
CRs-Fixed: 919417
